### PR TITLE
Update main.go

### DIFF
--- a/exporter/main.go
+++ b/exporter/main.go
@@ -84,13 +84,13 @@ func main() {
 	}()
 
 	//read credentials and stuff from environment
-	xmppUser, ok := os.LookupEnv("XMPP_USER")
+	xmppUser, ok := os.LookupEnv("PROMEXP_XMPP_USER")
 	if !ok {
 		fmt.Println("No user specified, failing")
 		os.Exit(2)
 	}
 
-	xmppPw, ok := os.LookupEnv("XMPP_PW")
+	xmppPw, ok := os.LookupEnv("PROMEXP_XMPP_PASSWORD")
 	if !ok {
 		fmt.Println("No password specified, failing")
 		os.Exit(2)
@@ -147,12 +147,14 @@ func main() {
 	jid := xmppUser + "@" + xmppAuthDomain
 	address := xmppServer + ":" + xmppPort
 	config := xmpp.Config{
-		Address:      address,
+		TransportConfiguration: xmpp.TransportConfiguration{
+			Address:      address,
+			TLSConfig:    &tls.Config{InsecureSkipVerify: true},
+		},
 		Jid:          jid,
-		Password:     xmppPw,
+		Credential:   xmpp.Password(xmppPw),
 		StreamLogger: os.Stdout,
 		Insecure:     true,
-		TLSConfig:    &tls.Config{InsecureSkipVerify: true},
 	}
 
 	router := xmpp.NewRouter()
@@ -261,10 +263,9 @@ func postConnect(s xmpp.Sender) {
 }
 
 func connectClient(c xmpp.Config, r *xmpp.Router) {
-	client, err := xmpp.NewClient(c, r)
+	client, err := xmpp.NewClient(c, r, errorHandler)
 	if err != nil {
 		fmt.Printf("unable to create client: %s\n", err.Error())
-		signals <- iFail
 	}
 
 	fmt.Println("starting streammanger")
@@ -281,4 +282,9 @@ func connectClient(c xmpp.Config, r *xmpp.Router) {
 	fmt.Println("XMPP connection closed, exiting.")
 	signals <- iExit
 	return
+}
+
+// If an error occurs, this is used to kill the client
+func errorHandler(err error) {
+	signals <- iFail
 }


### PR DESCRIPTION
this PR does 2 things:
1) renames XMPP_USER and  XMPP_PW env variables into PROMEXP_XMPP_USER and PROMEXP_XMPP_PASSWORD (so it is more compliant with jitsi naming standards) - we use k8s deployment and this collides with other things
2) solves compilation problems with new versions of FluuxIO/go-xmpp go xmpp library
./main.go:150:3: cannot use promoted field TransportConfiguration.Address in struct literal of type xmpp.Config
./main.go:152:3: unknown field 'Password' in struct literal of type xmpp.Config
./main.go:155:3: cannot use promoted field TransportConfiguration.TLSConfig in struct literal of type xmpp.Config
./main.go:264:31: not enough arguments in call to xmpp.NewClient
        have (xmpp.Config, *xmpp.Router)
        want (xmpp.Config, *xmpp.Router, func(error))

this patch doesnt update any documentation